### PR TITLE
Revert "Don't count job as in progress if a different strategy throttles it"

### DIFF
--- a/lib/sidekiq/throttled/strategy.rb
+++ b/lib/sidekiq/throttled/strategy.rb
@@ -112,7 +112,7 @@ module Sidekiq
         end
       end
 
-      # Marks job as not processing.
+      # Marks job as being processed.
       # @return [void]
       def finalize!(jid, *job_args)
         @concurrency&.finalize!(jid, *job_args)

--- a/lib/sidekiq/throttled/strategy/threshold.rb
+++ b/lib/sidekiq/throttled/strategy/threshold.rb
@@ -93,11 +93,6 @@ module Sidekiq
           Sidekiq.redis { |conn| conn.llen(key(job_args)) }.to_i
         end
 
-        # Marks job as not processing.
-        # No tracking of this is necessary for threshold.
-        # @return [void]
-        def finalize!(...); end
-
         # Resets count of jobs
         # @return [void]
         def reset!(*job_args)

--- a/lib/sidekiq/throttled/strategy_collection.rb
+++ b/lib/sidekiq/throttled/strategy_collection.rb
@@ -38,18 +38,7 @@ module Sidekiq
       # @return [Boolean] whenever job is throttled or not
       # by any strategy in collection.
       def throttled?(...)
-        allows = []
-
-        each do |s|
-          if s.throttled?(...)
-            allows.each { |s| s.finalize!(...) }
-            return true
-          else
-            allows << s
-          end
-        end
-
-        false
+        any? { |s| s.throttled?(...) }
       end
 
       # @return [Float] How long, in seconds, before we'll next be able to take on jobs

--- a/spec/lib/sidekiq/throttled/strategy_spec.rb
+++ b/spec/lib/sidekiq/throttled/strategy_spec.rb
@@ -138,8 +138,8 @@ RSpec.describe Sidekiq::Throttled::Strategy do
       let(:concurrency) do
         {
           concurrency: [
-            { limit: 7, key_suffix: ->(_, *) { 1 } },
-            { limit: 3, key_suffix: ->(job_arg, *) { job_arg } }
+            { limit: 3, key_suffix: ->(job_arg, *) { job_arg } },
+            { limit: 7, key_suffix: ->(_, *) { 1 } }
           ]
         }
       end
@@ -180,20 +180,11 @@ RSpec.describe Sidekiq::Throttled::Strategy do
         end
       end
 
-      context "with static key suffix" do
+      context "with second concurrency rule" do
         let(:job_args) { [10] }
 
         context "when limit is not yet reached" do
-          before do
-            in_progress_count = 0
-
-            # Since there is a limit of 3 the 4th job will not be
-            # enqueued and should not count towards the static limit of 7.
-            in_progress_count += 4.times.count { !strategy.throttled? jid, [99] }
-            in_progress_count += 3.times.count { |i| !strategy.throttled? jid, i }
-
-            raise "unexpected in_progress_count" if in_progress_count != 6
-          end
+          before { 6.times { |i| strategy.throttled? jid, i } }
 
           it { is_expected.to be false }
         end


### PR DESCRIPTION
Reverts ixti/sidekiq-throttled#222

We should revisit this upon next version