### PR TITLE
Guard Object.const_get with const_defined? to avoid autoloader deadlocks

### DIFF
--- a/lib/sidekiq/throttled.rb
+++ b/lib/sidekiq/throttled.rb
@@ -96,10 +96,17 @@ module Sidekiq
       # Return throttled job to be executed later, delegating the details of how to do that
       # to the Strategy for that job.
       #
+      # Uses +const_defined?+ before +const_get+ to avoid triggering
+      # autoloading (e.g. Zeitwerk) from Sidekiq's fetcher thread, which
+      # runs outside the Rails reloader and can deadlock or raise.
+      #
       # @return [void]
       def requeue_throttled(work)
         message = JSON.parse(work.job)
-        job_class = Object.const_get(message.fetch("wrapped") { message.fetch("class") { return false } })
+        class_name = message.fetch("wrapped") { message.fetch("class") { return false } }
+        return false unless Object.const_defined?(class_name)
+
+        job_class = Object.const_get(class_name)
 
         Registry.get job_class do |strategy|
           strategy.requeue_throttled(work)

--- a/lib/sidekiq/throttled.rb
+++ b/lib/sidekiq/throttled.rb
@@ -96,19 +96,12 @@ module Sidekiq
       # Return throttled job to be executed later, delegating the details of how to do that
       # to the Strategy for that job.
       #
-      # Uses +const_defined?+ before +const_get+ to avoid triggering
-      # autoloading (e.g. Zeitwerk) from Sidekiq's fetcher thread, which
-      # runs outside the Rails reloader and can deadlock or raise.
-      #
       # @return [void]
       def requeue_throttled(work)
         message = JSON.parse(work.job)
         class_name = message.fetch("wrapped") { message.fetch("class") { return false } }
-        return false unless Object.const_defined?(class_name)
 
-        job_class = Object.const_get(class_name)
-
-        Registry.get job_class do |strategy|
+        Registry.get class_name do |strategy|
           strategy.requeue_throttled(work)
         end
       end

--- a/lib/sidekiq/throttled/registry.rb
+++ b/lib/sidekiq/throttled/registry.rb
@@ -99,22 +99,22 @@ module Sidekiq
 
         # Find strategy by class or it's parents.
         #
-        # Uses +const_defined?+ before +const_get+ to avoid triggering
-        # autoloading (e.g. Zeitwerk) from Sidekiq's fetcher thread, which
-        # runs outside the Rails reloader and can deadlock or raise.
+        # Only performs ancestor lookup when +name+ is already a Class.
+        # String-based lookup via +Object.const_get+ is intentionally
+        # skipped because it triggers autoloading (e.g. Zeitwerk) from
+        # Sidekiq's fetcher thread, which runs outside the Rails reloader
+        # and can deadlock or raise. Use +Registry.add_alias+ to register
+        # subclasses that should inherit a parent's throttle strategy.
         #
         # @param name [Class, #to_s]
         # @return [Strategy, nil]
         def find_by_class(name)
-          const = name.is_a?(Class) ? name : (Object.const_get(name) if Object.const_defined?(name))
-          return unless const.is_a?(Class)
+          return unless name.is_a?(Class)
 
-          const.ancestors.each do |m|
+          name.ancestors.each do |m|
             strategy = find(m.name)
             return strategy if strategy
           end
-        rescue NameError
-          nil
         end
       end
     end

--- a/lib/sidekiq/throttled/registry.rb
+++ b/lib/sidekiq/throttled/registry.rb
@@ -106,20 +106,13 @@ module Sidekiq
         # @param name [Class, #to_s]
         # @return [Strategy, nil]
         def find_by_class(name)
-          const = if name.is_a?(Class)
-                    name
-                  elsif Object.const_defined?(name)
-                    Object.const_get(name)
-                  end
-
+          const = name.is_a?(Class) ? name : (Object.const_get(name) if Object.const_defined?(name))
           return unless const.is_a?(Class)
 
           const.ancestors.each do |m|
             strategy = find(m.name)
             return strategy if strategy
           end
-
-          nil
         rescue NameError
           nil
         end

--- a/lib/sidekiq/throttled/registry.rb
+++ b/lib/sidekiq/throttled/registry.rb
@@ -99,10 +99,19 @@ module Sidekiq
 
         # Find strategy by class or it's parents.
         #
+        # Uses +const_defined?+ before +const_get+ to avoid triggering
+        # autoloading (e.g. Zeitwerk) from Sidekiq's fetcher thread, which
+        # runs outside the Rails reloader and can deadlock or raise.
+        #
         # @param name [Class, #to_s]
         # @return [Strategy, nil]
         def find_by_class(name)
-          const = name.is_a?(Class) ? name : Object.const_get(name)
+          const = if name.is_a?(Class)
+                    name
+                  elsif Object.const_defined?(name)
+                    Object.const_get(name)
+                  end
+
           return unless const.is_a?(Class)
 
           const.ancestors.each do |m|

--- a/spec/support/sidekiq.rb
+++ b/spec/support/sidekiq.rb
@@ -73,7 +73,7 @@ module SidekiqThrottledHelper
   end
 end
 
-class PseudoLogger < Logger
+class PseudoLogger < Logger # rubocop:disable Style/OneClassPerFile
   include Singleton
 
   def initialize


### PR DESCRIPTION
## Problem

`Object.const_get` is called from Sidekiq's fetcher thread in two places:

1. `Registry.find_by_class` (via `Registry.get` → `Throttled.throttled?`)
2. `Throttled.requeue_throttled`

The fetcher thread runs **outside** the Rails reloader. When `const_get` encounters a constant that hasn't been loaded yet, it triggers Zeitwerk autoloading, which attempts to acquire the autoload lock. This conflicts with the Rails executor, causing either:

- A **deadlock** — the fetcher thread hangs forever, and the fetched job silently vanishes (our case with Sidekiq Pro's SuperFetch)
- A **`NameError`** — `uninitialized constant` (reported in #213)

**Note:** `Object.const_defined?` is NOT a safe guard here because Zeitwerk registers constants via `Module#autoload`, which causes `const_defined?` to return `true` for unloaded constants. Calling `const_get` after that still triggers autoloading.

## Fix

Remove all `Object.const_get` calls from the fetcher thread code path:

- **`Registry.find_by_class`**: Only walk ancestors when `name` is already a `Class` object. For string-based lookups, return `nil`. Users can use `Registry.add_alias` to explicitly register subclasses that should inherit a parent's throttle strategy.
- **`Throttled.requeue_throttled`**: Pass the class name string directly to `Registry.get` instead of resolving it with `const_get`. The string-based lookup via `Registry.find` is sufficient since strategies are registered by class name.

### Production behavior

- Jobs that call `sidekiq_throttle` directly continue to work — `Registry.find(name)` resolves them by string name
- Subclasses that previously relied on implicit ancestor lookup need an explicit `Registry.add_alias` call (e.g. in the subclass definition)

Fixes #213