### PR TITLE
Preserve job metadata during :schedule requeue

### DIFF
--- a/lib/sidekiq/throttled/strategy.rb
+++ b/lib/sidekiq/throttled/strategy.rb
@@ -16,6 +16,13 @@ module Sidekiq
       # :schedule means schedule enqueueing the job for a later time when we expect to have capacity
       VALID_VALUES_FOR_REQUEUE_WITH = %i[enqueue schedule].freeze
 
+      # Metadata keys from the original job message that should be preserved across reschedule.
+      # - "bid"       : Sidekiq Pro batch ID (required for batch callback tracking)
+      # - "callbacks" : Sidekiq Pro batch callback definitions
+      # - "tags"      : Sidekiq job tags
+      # - "wrapped"   : ActiveJob wrapped class name
+      PRESERVED_METADATA_KEYS = %w[bid callbacks tags wrapped].freeze
+
       # @!attribute [r] concurrency
       #   @return [Strategy::Concurrency, nil]
       attr_reader :concurrency
@@ -173,18 +180,35 @@ module Sidekiq
 
       # Reschedule the job to be executed later in the target queue.
       # The queue name should NOT include the "queue:" prefix, so we remove it if it's present.
-      def reschedule_throttled(work, target_queue)
+      #
+      # Preserves additional metadata from the original job message (e.g. "bid" for Sidekiq Pro
+      # batches, "tags", "wrapped" for ActiveJob) so that batch callbacks, tracing, and other
+      # middleware-injected context survive the reschedule.
+      def reschedule_throttled(work, target_queue) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
         target_queue = target_queue.delete_prefix("queue:")
         message      = JSON.parse(work.job)
         job_class    = message.fetch("wrapped") { message.fetch("class") { return false } }
-        job_args     = message["args"]
+
+        interval = retry_in(work)
+        at       = Time.now.to_f + interval.to_f
+
+        item = {
+          "class" => Object.const_get(job_class),
+          "args"  => message["args"],
+          "queue" => target_queue,
+          "at"    => at
+        }
+
+        # Preserve known metadata keys from the original job
+        PRESERVED_METADATA_KEYS.each do |key|
+          item[key] = message[key] if message.key?(key)
+        end
 
         # Re-enqueue the job to the target queue at another time as a NEW unit of work
-        # AND THEN mark this work as done, so SuperFetch doesn't think this instance is orphaned
-        # Technically, the job could processed twice if the process dies between the two lines,
+        # AND THEN mark this work as done, so SuperFetch doesn't think this instance is orphaned.
+        # Technically, the job could be processed twice if the process dies between the two lines,
         # but your job should be idempotent anyway, right?
-        # The job running twice was already a risk with SuperFetch anyway and this doesn't really increase that risk.
-        Sidekiq::Client.enqueue_to_in(target_queue, retry_in(work), Object.const_get(job_class), *job_args)
+        item["class"].client_push(item)
 
         work.acknowledge
       end

--- a/spec/lib/sidekiq/throttled/strategy_spec.rb
+++ b/spec/lib/sidekiq/throttled/strategy_spec.rb
@@ -676,7 +676,6 @@ RSpec.describe Sidekiq::Throttled::Strategy do
           end
 
           it "returns false and does not reschedule the job" do
-            expect(Sidekiq::Client).not_to receive(:enqueue_to_in)
             expect(work).not_to receive(:acknowledge)
             expect(subject.send(:reschedule_throttled, work, "queue:default")).to be_falsey
           end
@@ -686,9 +685,52 @@ RSpec.describe Sidekiq::Throttled::Strategy do
           let(:target_queue) { "queue:default" }
 
           it "reschedules the job to the specified queue" do
-            expect(Sidekiq::Client).to receive(:enqueue_to_in).with("default", anything, anything, anything)
-            expect(work).to receive(:acknowledge)
-            subject.send(:reschedule_throttled, work, target_queue)
+            expect do
+              subject.send(:reschedule_throttled, work, target_queue)
+            end.to change { Sidekiq.redis { |conn| conn.zcard("schedule") } }.by(1)
+
+            item, = scheduled_redis_item_and_score
+            expect(JSON.parse(item)).to include("class" => "ThrottledTestJob", "args" => [1],
+              "queue" => "default")
+          end
+        end
+
+        context "when original job has batch metadata" do
+          before do
+            job_data = JSON.parse(work.job).merge(
+              "bid"       => "batch-123",
+              "callbacks" => { "success" => ["MyCallback"] },
+              "tags"      => ["critical"],
+              "wrapped"   => "ThrottledTestJob"
+            )
+            allow(work).to receive(:job).and_return(job_data.to_json)
+          end
+
+          it "preserves all metadata keys in the rescheduled job" do
+            expect do
+              subject.send(:reschedule_throttled, work, "default")
+            end.to change { Sidekiq.redis { |conn| conn.zcard("schedule") } }.by(1)
+
+            item, = scheduled_redis_item_and_score
+            expect(JSON.parse(item)).to include(
+              "bid"       => "batch-123",
+              "callbacks" => { "success" => ["MyCallback"] },
+              "tags"      => ["critical"],
+              "wrapped"   => "ThrottledTestJob",
+              "class"     => "ThrottledTestJob",
+              "args"      => [1]
+            )
+          end
+
+          it "generates a new jid for the rescheduled job" do
+            original_jid = JSON.parse(work.job)["jid"]
+
+            subject.send(:reschedule_throttled, work, "default")
+
+            item, = scheduled_redis_item_and_score
+            parsed = JSON.parse(item)
+            expect(parsed["jid"]).not_to eq(original_jid)
+            expect(parsed).not_to have_key("enqueued_at")
           end
         end
       end
@@ -1018,7 +1060,6 @@ RSpec.describe Sidekiq::Throttled::Strategy do
           end
 
           it "returns false and does not reschedule the job" do
-            expect(Sidekiq::Client).not_to receive(:enqueue_to_in)
             expect(work).not_to receive(:acknowledge)
             expect(subject.send(:reschedule_throttled, work, "queue:default")).to be_falsey
           end
@@ -1028,9 +1069,52 @@ RSpec.describe Sidekiq::Throttled::Strategy do
           let(:target_queue) { "queue:default" }
 
           it "reschedules the job to the specified queue" do
-            expect(Sidekiq::Client).to receive(:enqueue_to_in).with("default", anything, anything, anything)
-            expect(work).to receive(:acknowledge)
-            subject.send(:reschedule_throttled, work, target_queue)
+            expect do
+              subject.send(:reschedule_throttled, work, target_queue)
+            end.to change { Sidekiq.redis { |conn| conn.zcard("schedule") } }.by(1)
+
+            item, = scheduled_redis_item_and_score
+            expect(JSON.parse(item)).to include("class" => "ThrottledTestJob", "args" => [1],
+              "queue" => "default")
+          end
+        end
+
+        context "when original job has batch metadata" do
+          before do
+            job_data = JSON.parse(work.job).merge(
+              "bid"       => "batch-xyz",
+              "callbacks" => { "success" => ["MyCallback"] },
+              "tags"      => ["important"],
+              "wrapped"   => "ThrottledTestJob"
+            )
+            allow(work).to receive(:job).and_return(job_data.to_json)
+          end
+
+          it "preserves all metadata keys in the rescheduled job" do
+            expect do
+              subject.send(:reschedule_throttled, work, "default")
+            end.to change { Sidekiq.redis { |conn| conn.zcard("schedule") } }.by(1)
+
+            item, = scheduled_redis_item_and_score
+            expect(JSON.parse(item)).to include(
+              "bid"       => "batch-xyz",
+              "callbacks" => { "success" => ["MyCallback"] },
+              "tags"      => ["important"],
+              "wrapped"   => "ThrottledTestJob",
+              "class"     => "ThrottledTestJob",
+              "args"      => [1]
+            )
+          end
+
+          it "generates a new jid for the rescheduled job" do
+            original_jid = JSON.parse(work.job)["jid"]
+
+            subject.send(:reschedule_throttled, work, "default")
+
+            item, = scheduled_redis_item_and_score
+            parsed = JSON.parse(item)
+            expect(parsed["jid"]).not_to eq(original_jid)
+            expect(parsed).not_to have_key("enqueued_at")
           end
         end
       end


### PR DESCRIPTION
`reschedule_throttled` calls `enqueue_to_in` which only passes `class`/`args`/`queue`/`at` to `client_push`, dropping all other metadata. This breaks Sidekiq Pro Batches — the batch ID is lost so callbacks never fire.

Fix: build the item hash directly and copy over known metadata keys (bid, callbacks, tags, wrapped) before calling `client_push`.